### PR TITLE
✨ feat(auditable): Add deleted_at field to auditable entity and update migrations

### DIFF
--- a/server/app-authorization/src/db/migrations/1743459951186-updatedAuditableentitie.ts
+++ b/server/app-authorization/src/db/migrations/1743459951186-updatedAuditableentitie.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdatedAuditableentitie1743459951186 implements MigrationInterface {
+    name = 'UpdatedAuditableentitie1743459951186'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`sec_refresh_tokens\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_role_focus\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_element_types\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_view_configurations\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_role_functional_permissions\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_endpoint_permissions\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_role_endpoint_permissions\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_user_role_contracts\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_roles\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_user_roles\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`user_status\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_users\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_user_role_results\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_entity_types\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_organizational_entities\` ADD \`deleted_at\` timestamp NULL`);
+        await queryRunner.query(`ALTER TABLE \`sec_template\` ADD \`deleted_at\` timestamp NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`sec_template\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_organizational_entities\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_entity_types\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_user_role_results\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_users\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`user_status\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_user_roles\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_roles\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_user_role_contracts\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_role_endpoint_permissions\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_endpoint_permissions\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_role_functional_permissions\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_view_configurations\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_element_types\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_role_focus\` DROP COLUMN \`deleted_at\``);
+        await queryRunner.query(`ALTER TABLE \`sec_refresh_tokens\` DROP COLUMN \`deleted_at\``);
+    }
+
+}

--- a/server/app-authorization/src/domain/shared/global-dto/auditable.entity.ts
+++ b/server/app-authorization/src/domain/shared/global-dto/auditable.entity.ts
@@ -5,9 +5,8 @@ export abstract class AuditableEntity {
     type: 'timestamp',
     name: 'created_at',
     nullable: false,
-    select: false,
   })
-  created_at: Date;
+  created_at?: Date;
 
   @Column({
     type: 'bigint',
@@ -15,15 +14,14 @@ export abstract class AuditableEntity {
     nullable: true,
     select: false,
   })
-  created_by: number;
+  created_by?: number;
 
   @UpdateDateColumn({
     type: 'timestamp',
     name: 'updated_at',
     nullable: true,
-    select: false,
   })
-  updated_at: Date;
+  updated_at?: Date;
 
   @Column({
     type: 'bigint',
@@ -31,7 +29,7 @@ export abstract class AuditableEntity {
     nullable: true,
     select: false,
   })
-  updated_by: number;
+  updated_by?: number;
 
   @Column({
     name: 'is_active',
@@ -41,4 +39,12 @@ export abstract class AuditableEntity {
     select: true,
   })
   is_active: boolean;
+
+  @Column({
+    name: 'deleted_at',
+    type: 'timestamp',
+    nullable: true,
+    select: false,
+  })
+  deleted_at?: Date;
 }


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of soft deletes across various database tables and updates the `AuditableEntity` class to support this functionality. The most important changes include adding a `deleted_at` column to multiple database tables, modifying the `AuditableEntity` class to include the new `deleted_at` property, and updating the type definitions of existing properties for better flexibility.

### Database Migration Updates:
* Added a `deleted_at` column (nullable `timestamp`) to multiple tables, including `sec_refresh_tokens`, `sec_roles`, `sec_users`, and others, to support soft delete functionality. Corresponding `up` and `down` methods were implemented in the migration file `1743459951186-updatedAuditableentitie.ts`.

### Updates to `AuditableEntity` Class:
* Added a new `deleted_at` property (nullable `timestamp`) to the `AuditableEntity` class for soft delete support.
* Updated the type definitions of the `created_at`, `created_by`, `updated_at`, and `updated_by` properties in the `AuditableEntity` class to make them optional, improving flexibility.