### PR TITLE
✨ fix(docker): Update Node.js version in Dockerfile to 20.13.1-alpine

### DIFF
--- a/server/app-authorization/Dockerfile
+++ b/server/app-authorization/Dockerfile
@@ -1,6 +1,6 @@
 #################### BASE STAGE ####################
 # Base image
-FROM node:20-alpine as base
+FROM node:20.13.1-alpine AS base
 
 # Create app directory
 WORKDIR /app
@@ -38,7 +38,7 @@ RUN npm run build
 #################### PRODUCTION STAGE ####################
 
 # Base image
-FROM --platform=linux/amd64 node:latest as production
+FROM --platform=linux/amd64 node:20.13.1-alpine AS production
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the `server/app-authorization/Dockerfile` to standardize the Node.js version used across different stages of the Docker build process. The most important changes include specifying a fixed Node.js version (`20.13.1-alpine`) for both the base and production stages, ensuring consistency and reducing potential compatibility issues.

### Dockerfile updates:

* Updated the base stage to use `node:20.13.1-alpine` instead of `node:20-alpine`.
* Updated the production stage to use `node:20.13.1-alpine` instead of `node:latest`, ensuring a consistent and predictable Node.js version.