### PR TITLE
✨ fix(ci): Remove 'staging-action-v2' branch from SonarCloud analysis  workflow

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -2,9 +2,9 @@ name: SonarCloud Analysis - NestJS Backend
 
 on:
   push:
-    branches: [dev, staging, main, staging-action-v2]
+    branches: [dev, staging, main]
   pull_request:
-    branches: [dev, staging, main, staging-action-v2]
+    branches: [dev, staging, main]
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
This pull request updates the `.github/workflows/sonarcloud-analysis.yml` file to streamline the branch configuration for the SonarCloud Analysis workflow by removing the `staging-action-v2` branch from both `push` and `pull_request` triggers.

Branch configuration updates:

* [`.github/workflows/sonarcloud-analysis.yml`](diffhunk://#diff-7069e33747a5e54d51fd9be63ad0df207cd4380c0e0f84e07c59371fd178e5ecL5-R7): Removed the `staging-action-v2` branch from the `push` and `pull_request` triggers to simplify the workflow configuration.