### PR TITLE
✨ fix(docker): Switch to non-root user in Dockerfile for enhanced security

### DIFF
--- a/server/app-authorization/Dockerfile
+++ b/server/app-authorization/Dockerfile
@@ -24,6 +24,9 @@ COPY eslint.config.mjs ./
 # Creates a "dist" folder with the production build
 RUN npm run build
 
+# Switch to non-root user
+USER appuser
+
 # Expose the port on which the app will run
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `server/app-authorization/Dockerfile`. The change ensures better security by switching to a non-root user (`appuser`) after the build process.