### PR TITLE
Enhance login process with user role and staff validation

### DIFF
--- a/server/app-authorization/src/db/migrations/1764186099439-updateSecUsers.ts
+++ b/server/app-authorization/src/db/migrations/1764186099439-updateSecUsers.ts
@@ -1,14 +1,15 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class UpdateSecUsers1764186099439 implements MigrationInterface {
-    name = 'UpdateSecUsers1764186099439'
+  name = 'UpdateSecUsers1764186099439';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`sec_users\` ADD \`carnet\` varchar(10) NULL`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`sec_users\` ADD \`carnet\` varchar(10) NULL`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`sec_users\` DROP COLUMN \`carnet\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`sec_users\` DROP COLUMN \`carnet\``);
+  }
 }

--- a/server/app-authorization/src/db/migrations/1776443271722-UpdateRoleTable.ts
+++ b/server/app-authorization/src/db/migrations/1776443271722-UpdateRoleTable.ts
@@ -1,16 +1,23 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class UpdateRoleTable1776443271722 implements MigrationInterface {
-    name = 'UpdateRoleTable1776443271722'
+  name = 'UpdateRoleTable1776443271722';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`sec_roles\` ADD \`description\` text NULL`);
-        await queryRunner.query(`ALTER TABLE \`sec_roles\` ADD \`is_internal\` tinyint NOT NULL DEFAULT 0`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`sec_roles\` ADD \`description\` text NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`sec_roles\` ADD \`is_internal\` tinyint NOT NULL DEFAULT 0`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`sec_roles\` DROP COLUMN \`is_internal\``);
-        await queryRunner.query(`ALTER TABLE \`sec_roles\` DROP COLUMN \`description\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`sec_roles\` DROP COLUMN \`is_internal\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`sec_roles\` DROP COLUMN \`description\``,
+    );
+  }
 }

--- a/server/app-authorization/src/db/migrations/1778160651143-addednewUserStatus.ts
+++ b/server/app-authorization/src/db/migrations/1778160651143-addednewUserStatus.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { UserStatusEnum } from "../../domain/entities/user-status/enum/user-status.enum";
+
+export class AddednewUserStatus1778160651143 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            INSERT INTO user_status (user_status_id, name)
+            VALUES (${UserStatusEnum.EXTERNAL_ACCEPTED}, 'External Accepted');
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DELETE FROM user_status WHERE user_status_id = ${UserStatusEnum.EXTERNAL_ACCEPTED};
+        `);
+    }
+
+}

--- a/server/app-authorization/src/domain/complementary-entities/secondary/app-config/app-config.entity.ts
+++ b/server/app-authorization/src/domain/complementary-entities/secondary/app-config/app-config.entity.ts
@@ -1,0 +1,57 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { AuditableEntity } from '../../../shared/global-dto/auditable.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('app_config')
+export class AppConfig extends AuditableEntity {
+  @PrimaryColumn({ type: 'varchar', length: 255 })
+  key: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'description',
+  })
+  description: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'category',
+  })
+  category: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'subcategory',
+  })
+  subcategory: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'field',
+  })
+  field: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'simple_value',
+  })
+  simple_value: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'json',
+    nullable: true,
+    name: 'json_value',
+  })
+  json_value: any;
+}

--- a/server/app-authorization/src/domain/entities/authorization.service.ts
+++ b/server/app-authorization/src/domain/entities/authorization.service.ts
@@ -30,9 +30,9 @@ export class AuthorizationService {
     private readonly _usersService: UsersService,
   ) {}
 
-  login(profileData: CognitoProfileDto): Promise<ResponseAccessTokenDto> {
+  async login(profileData: CognitoProfileDto): Promise<ResponseAccessTokenDto> {
     const email: string = profileData.email?.trim().toLocaleLowerCase();
-    const isCgir: boolean = email.includes('@cgiar.org');
+    const userStaff = await this._usersService.validateUserStaff(email);
     const access: Promise<AccessTokenDto> = this._usersService
       .findUserLogin(email)
       .then(async (user: User) => {
@@ -43,7 +43,7 @@ export class AuthorizationService {
           throw new UnauthorizedException(
             'The user is rejected please contact the support team',
           );
-        if (!tempUser && isCgir) {
+        if (!tempUser && userStaff) {
           tempUser = await this._usersService
             .create({
               email: email,
@@ -58,7 +58,7 @@ export class AuthorizationService {
                */
               return await this._usersService.findById(data.sec_user_id);
             });
-        } else if (!tempUser && !isCgir) {
+        } else if (!tempUser) {
           await this._usersService.create(
             {
               email: email,
@@ -74,6 +74,8 @@ export class AuthorizationService {
         }
 
         if (tempUser) {
+          await this.validateUserStaff(tempUser, userStaff);
+
           await this.dataSource
             .getRepository(User)
             .update(
@@ -116,6 +118,23 @@ export class AuthorizationService {
           };
         });
     });
+  }
+
+  private async validateUserStaff(user: User, isCiat: boolean): Promise<void> {
+    if (user.status_id !== UserStatusEnum.EXTERNAL_ACCEPTED) {
+      if (!isCiat) {
+        await this.dataSource
+          .getRepository(User)
+          .update(
+            { sec_user_id: user.sec_user_id },
+            { status_id: UserStatusEnum.PENDING },
+          );
+
+        throw new UnauthorizedException(
+          'Your access is restricted until your user is approved. You will be notified by email.',
+        );
+      }
+    }
   }
 
   private generateToken(user: User): string {

--- a/server/app-authorization/src/domain/entities/user-status/enum/user-status.enum.ts
+++ b/server/app-authorization/src/domain/entities/user-status/enum/user-status.enum.ts
@@ -2,4 +2,7 @@ export enum UserStatusEnum {
   ACCEPTED = 1,
   PENDING = 2,
   REJECTED = 3,
+  EXTERNAL_ACCEPTED = 4,
 }
+
+//si ya no esta en staff entonces se cambia a pending

--- a/server/app-authorization/src/domain/entities/users/repositories/users.repository.ts
+++ b/server/app-authorization/src/domain/entities/users/repositories/users.repository.ts
@@ -57,6 +57,23 @@ export class UserRepository extends Repository<User> {
                   GROUP BY t.app_secret_id`;
     return this.query(query, [appSecretUuid]).then((res) => res?.[0] ?? null);
   }
+
+  async validateUserStaff(
+    email: string,
+  ): Promise<{ email: string; carnet: string } | null> {
+    const query = `
+      SELECT su.email, aus.carnet 
+      FROM sec_users su 
+        INNER JOIN alliance_user_staff aus ON LOWER(TRIM(su.email)) = LOWER(TRIM(aus.email))
+      WHERE aus.carnet IS NOT NULL
+        AND LOWER(TRIM(su.email)) LIKE ?
+        AND su.is_active = TRUE
+        AND aus.is_active = TRUE
+      LIMIT 1
+    `;
+    const result = await this.query(query, [`%${email}%`]);
+    return result?.[0] ?? null;
+  }
 }
 
 export type UserWithHosts = {

--- a/server/app-authorization/src/domain/entities/users/users.service.ts
+++ b/server/app-authorization/src/domain/entities/users/users.service.ts
@@ -38,6 +38,13 @@ export class UsersService {
     });
   }
 
+  async validateUserStaff(email: string): Promise<boolean> {
+    const user = await this.mainRepo.validateUserStaff(email);
+    if (!user) return false;
+
+    return true;
+  }
+
   async create(
     newUser: CreateUserDto,
     isPending: boolean = false,

--- a/server/app-authorization/src/domain/shared/utils/app_config.util.ts
+++ b/server/app-authorization/src/domain/shared/utils/app_config.util.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AppConfig } from '../../complementary-entities/secondary/app-config/app-config.entity';
+
+@Injectable()
+export class AppConfigUtil {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async DB_SUPPORT_EMAIL(): Promise<string> {
+    const appConfig = await this.dataSource.getRepository(AppConfig).findOne({
+      where: {
+        key: 'ARI_SUPPORT_EMAIL',
+      },
+    });
+    return appConfig?.simple_value;
+  }
+}

--- a/server/app-authorization/src/domain/shared/utils/global-utils.module.ts
+++ b/server/app-authorization/src/domain/shared/utils/global-utils.module.ts
@@ -1,9 +1,10 @@
 import { Module, Global } from '@nestjs/common';
 import { CurrentUserUtil } from './current-user.util';
+import { AppConfigUtil } from './app_config.util';
 
 @Global()
 @Module({
-  providers: [CurrentUserUtil],
-  exports: [CurrentUserUtil],
+  providers: [CurrentUserUtil, AppConfigUtil],
+  exports: [CurrentUserUtil, AppConfigUtil],
 })
 export class GlobalUtilsModule {}


### PR DESCRIPTION

## Commits
1. **feat(authorization):** Enhance login process with user staff validation and add `EXTERNAL_ACCEPTED` status to `UserStatusEnum`
2. **feat(authorization):** Implement user role validation during login and update `UserStatusEnum` with `EXTERNAL_ACCEPTED` status
---
## Functional changes
### Login flow (`authorization.service.ts`)
- **`login`** is now **`async`** and resolves **“internal / staff”** eligibility via **`UsersService.validateUserStaff(email)`** instead of `email.includes('@cgiar.org')`.
- **New-user creation:** Logic that previously branched on CGIAR domain now uses the **staff validation result** (`userStaff`) for the same auto-provisioning paths.
- **Existing users:** After a user record exists, **`validateUserStaff(tempUser, userStaff)`** runs before token issuance / updates.
### Staff gate for existing users (`validateUserStaff`)
New private method:
- If the user’s **`status_id` is not `UserStatusEnum.EXTERNAL_ACCEPTED`** and **`userStaff` is false** (not found as active staff with a non-null `carnet`):
  - The user’s status is set to **`PENDING`**.
  - Login fails with **`UnauthorizedException`** and message: *“Your access is restricted until your user is approved. You will be notified by email.”*
- Users in **`EXTERNAL_ACCEPTED`** are **not** subjected to this staff check (bypass for externally accepted accounts).
### Staff lookup (`users.repository.ts` + `users.service.ts`)
- **`UserRepository.validateUserStaff(email)`** runs SQL joining **`sec_users`** and **`alliance_user_staff`** on normalized email (`LOWER(TRIM(...))`), requiring:
  - Matching email pattern (`LIKE ?` with `%email%`),
  - **`carnet` IS NOT NULL**,
  - **`su.is_active = TRUE`** and **`aus.is_active = TRUE`**.
- **`UsersService.validateUserStaff`** returns **`true`** if a row is found, else **`false`**.
---
## Data model & migrations
### New enum value
- **`UserStatusEnum.EXTERNAL_ACCEPTED = 4`** added in `user-status.enum.ts`.
### New migration
- **`1778160651143-addednewUserStatus.ts`**: inserts into **`user_status`** the row for `EXTERNAL_ACCEPTED` / `'External Accepted'`; `down` deletes that row.
### Formatting-only migrations
- **`1764186099439-updateSecUsers.ts`** and **`1776443271722-UpdateRoleTable.ts`**: quote style, indentation, and line wrapping only — **no semantic SQL change**.
---
## Application configuration (new building blocks)
- **Entity:** `app-config.entity.ts` — maps table **`app_config`** (`key` PK, `description`, `category`, `subcategory`, `field`, `simple_value`, `json_value`, auditable columns).
- **Utility:** `app_config.util.ts` — **`AppConfigUtil.DB_SUPPORT_EMAIL()`** reads **`ARI_SUPPORT_EMAIL`** from `app_config` and returns `simple_value`.
- **Module wiring:** `GlobalUtilsModule` registers and exports **`AppConfigUtil`** alongside **`CurrentUserUtil`**.
> **Note:** In this diff, `AppConfigUtil` is **introduced and wired** but **not** referenced from `authorization.service.ts`; consumers can use it elsewhere for support email or future messaging.
---
## Operational / deployment notes
1. **Run migrations** so `user_status` includes **`EXTERNAL_ACCEPTED`** before relying on the new enum value in code.
2. Ensure **`alliance_user_staff`** data is correct and **`carnet`** populated where staff login should succeed.
3. If **`app_config`** / **`ARI_SUPPORT_EMAIL`** is required at runtime for other features, seed or migrate those rows as appropriate.
---
## Files changed
| Area | File |
|------|------|
| Login & rules | `src/domain/entities/authorization.service.ts` |
| Staff query | `src/domain/entities/users/repositories/users.repository.ts` |
| Staff API | `src/domain/entities/users/users.service.ts` |
| Status enum | `src/domain/entities/user-status/enum/user-status.enum.ts` |
| New migration | `src/db/migrations/1778160651143-addednewUserStatus.ts` |
| Migrations (format) | `src/db/migrations/1764186099439-updateSecUsers.ts`, `1776443271722-UpdateRoleTable.ts` |
| App config | `src/domain/complementary-entities/secondary/app-config/app-config.entity.ts` |
| App config util | `src/domain/shared/utils/app_config.util.ts` |
| Module | `src/domain/shared/utils/global-utils.module.ts` |
---